### PR TITLE
README: URL de produção para novo hamburgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Existem muitos "padrões" diferentes para a emissão de NFSe, além disso, cada 
 - Nobres (MT) Nota: incompleto falta URL de produção
 - Nova Alvorada do Sul (MS) Nota: incompleto falta URL de produção
 - Nova Olimpia (MT) Nota: incompleto falta URL de produção
-- Novo Hamburgo (RS) Nota: incompleto falta URL de produção
+- Novo Hamburgo (RS)
 - Praia Grande (SP) Nota: incompleto falta URL de produção
 - Ribeirão Preto (SP) : ABRASF (modificado)
 - Rio Brilhante (MS) Nota: incompleto falta URL de produção

--- a/src/Counties/M4313409/Tools.php
+++ b/src/Counties/M4313409/Tools.php
@@ -26,7 +26,7 @@ class Tools extends ToolsModel
      * @var array
      */
     protected $url = [
-        1 => '',
+        1 => 'http://www.issnetonline.com.br/webserviceabrasf/novohamburgo/servicos.asmx',
         2 => 'http://www.issnetonline.com.br/webserviceabrasf/homologacao/servicos.asmx'
     ];
     /**


### PR DESCRIPTION
Tinha esquecido de remover o aviso do readme, dizendo que não tinha a url de produção.